### PR TITLE
Bug/user delete and bugs

### DIFF
--- a/src/main/java/com/sololevelling/gym/sololevelling/repo/DungeonRepository.java
+++ b/src/main/java/com/sololevelling/gym/sololevelling/repo/DungeonRepository.java
@@ -21,6 +21,7 @@ import java.util.List;
 @Repository
 public interface DungeonRepository extends MongoRepository<Dungeon, ObjectId> {
     List<Dungeon> findByUser(User user);
+    List<Dungeon> findDungeonsByUser_Id(ObjectId objectId);
 
     List<Dungeon> findByUserAndCompletedFalse(User user);
 

--- a/src/main/java/com/sololevelling/gym/sololevelling/repo/ExerciseRepository.java
+++ b/src/main/java/com/sololevelling/gym/sololevelling/repo/ExerciseRepository.java
@@ -15,6 +15,9 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ExerciseRepository extends MongoRepository<Exercise, ObjectId> {
+    List<Exercise> findExercisesByWorkout_Id(ObjectId id);
 }

--- a/src/main/java/com/sololevelling/gym/sololevelling/repo/InventoryItemRepository.java
+++ b/src/main/java/com/sololevelling/gym/sololevelling/repo/InventoryItemRepository.java
@@ -21,4 +21,5 @@ import java.util.List;
 @Repository
 public interface InventoryItemRepository extends MongoRepository<InventoryItem, ObjectId> {
     List<InventoryItem> findByUser(User user);
+    List<InventoryItem> findInventoryItemsByUser_Id(ObjectId objectId);
 }

--- a/src/main/java/com/sololevelling/gym/sololevelling/repo/StatSnapshotRepository.java
+++ b/src/main/java/com/sololevelling/gym/sololevelling/repo/StatSnapshotRepository.java
@@ -15,6 +15,9 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface StatSnapshotRepository extends MongoRepository<StatSnapshot, ObjectId> {
+    List<StatSnapshot> findStatSnapshotsByUser_Id(ObjectId objectId);
 }

--- a/src/main/java/com/sololevelling/gym/sololevelling/repo/WorkoutRepository.java
+++ b/src/main/java/com/sololevelling/gym/sololevelling/repo/WorkoutRepository.java
@@ -21,4 +21,5 @@ import java.util.List;
 @Repository
 public interface WorkoutRepository extends MongoRepository<Workout, ObjectId> {
     List<Workout> findByUser(User user);
+    List<Workout> findWorkoutsByUser_Id(ObjectId id);
 }

--- a/src/main/java/com/sololevelling/gym/sololevelling/service/AdminService.java
+++ b/src/main/java/com/sololevelling/gym/sololevelling/service/AdminService.java
@@ -18,6 +18,7 @@ import com.sololevelling.gym.sololevelling.repo.*;
 import com.sololevelling.gym.sololevelling.util.AccessDeniedException;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.repository.support.SimpleMongoRepository;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +48,8 @@ public class AdminService {
     private RefreshTokenRepository refreshTokenRepository;
     @Autowired
     private StatSnapshotRepository statSnapshotRepository;
+    @Autowired
+    private ExerciseRepository exerciseRepo;
 
     public StatsResponse getDashboardStats() {
         long users = userRepo.count();
@@ -94,7 +97,12 @@ public class AdminService {
         questRepo.deleteAll(quests);
 
         List<Workout> workouts = workoutRepo.findWorkoutsByUser_Id(userId);
+        for (Workout workout : workouts) {
+            List<Exercise> exercises = exerciseRepo.findExercisesByWorkout_Id(workout.getId());
+            exerciseRepo.deleteAll(exercises);
+        }
         workoutRepo.deleteAll(workouts);
+
 
         List<InventoryItem> items = inventoryItemRepository.findInventoryItemsByUser_Id(userId);
         inventoryItemRepository.deleteAll(items);

--- a/src/main/java/com/sololevelling/gym/sololevelling/service/WorkoutService.java
+++ b/src/main/java/com/sololevelling/gym/sololevelling/service/WorkoutService.java
@@ -81,7 +81,12 @@ public class WorkoutService {
 
         // 5. Update user XP
         user.setExperience(user.getExperience() + xp);
-        user.setWorkouts(List.of(workout));
+        List<Workout> workouts = user.getWorkouts();
+        if (workouts == null){
+            workouts = new ArrayList<>();
+        }
+        workouts.add(workout);
+        user.setWorkouts(workouts);
         userRepository.save(user);
 
         return WorkoutMapper.toDto(workout);


### PR DESCRIPTION
This PR enhances the deleteUser functionality to ensure all related domain data is properly deleted when a user is removed from the system.

Previously, deleting a user only removed the User entity and a few direct relations such as tokens.
However, many linked collections (Workouts, Exercises, Quests, etc.) remained in the database, leading to referential inconsistencies.